### PR TITLE
Fix: Corrected the view recipe link with the correct source-url from …

### DIFF
--- a/projects/recipe-book-app/index.js
+++ b/projects/recipe-book-app/index.js
@@ -21,7 +21,7 @@ function displayRecipes(recipes) {
     `;
 
     recipeLinkEl = document.createElement("a");
-    recipeLinkEl.href = recipe.sourceUrl;
+    recipeLinkEl.href = recipe.spoonacularSourceUrl;
     recipeLinkEl.innerText = "View Recipe";
 
     recipeItemEl.appendChild(recipeImageEl);


### PR DESCRIPTION
As mentioned in issue#40, the  **VIEW RECIPE** link was not rendering properly as the recipe object was linked to 'sourceUrl', which was leading to the error.

![image](https://github.com/user-attachments/assets/58424757-8d25-444c-9f92-6340503dc122)

The recipe object from the API has another key called 'spoonacularSourceUrl' which is linked to the correct recipe link.
![Screenshot 2024-07-14 182814](https://github.com/user-attachments/assets/b022fffd-4f8e-46f7-9959-1c6e2e15725b)
