### PR TITLE
Multiple "Start" Clicks Speed Up the Timer

### DIFF
--- a/projects/pomodoro-timer/index.js
+++ b/projects/pomodoro-timer/index.js
@@ -23,9 +23,9 @@ function startTimer() {
     updateTimer();
     if (timeLeft === 0) {
       clearInterval(interval);
-      interval = null;
       alert("Time's up!");
       timeLeft = 1500;
+      interval = null;
       updateTimer();
     }
   }, 1000);

--- a/projects/pomodoro-timer/index.js
+++ b/projects/pomodoro-timer/index.js
@@ -17,11 +17,13 @@ function updateTimer() {
 }
 
 function startTimer() {
+  if (interval) return;
   interval = setInterval(() => {
     timeLeft--;
     updateTimer();
     if (timeLeft === 0) {
       clearInterval(interval);
+      interval = null;
       alert("Time's up!");
       timeLeft = 1500;
       updateTimer();
@@ -30,9 +32,11 @@ function startTimer() {
 }
 function stopTimer() {
   clearInterval(interval);
+  interval = null;
 }
 function resetTimer() {
   clearInterval(interval);
+  interval = null;
   timeLeft = 1500;
   updateTimer();
 }


### PR DESCRIPTION
Initially, in the Pomodoro Timer project, when we clicked the **"Start"** button once, the timer would begin as expected.  
But **if we clicked "Start" again and again, the timer would run faster than normal**. Why?

Because each time we clicked the "Start" button, it started a new interval using `setInterval`,  
which means multiple timers were running at the same time — each one reducing `timeLeft` every second.  
So the countdown speed increased unnaturally.

---

### **Step 1: Preventing Multiple Intervals**  

To solve this, I added the line:

```js
if (interval) return;
```

at the top of the `startTimer()` function.

This line checks if the interval is already running. If yes, it just exits and does nothing.  
This means now, even if the user clicks "Start" multiple times, it won’t create new intervals.

 **Result:** The timer no longer speeds up when we click "Start" multiple times.

---

### **New Issue After Fix: "Start" Didn’t Work After Stop**  

After adding that check, a new issue appeared.  When we clicked  "Stop" and then clicked  "Start" again, it wouldn’t resume from where it stopped.

**Why did this happen?**

Because after calling `clearInterval(interval)` in the `stopTimer()` function,  
we forgot to reset the `interval` variable back to `null`.  
So `interval` still had a value, and our new condition kept blocking the timer from restarting.

---

### **Step 2: Resetting the Interval Variable**  

To solve this, I added:

```js
interval = null;
```

at the end of all three functions:  
`startTimer()`, `stopTimer()`, and `resetTimer()` — wherever the interval was cleared.
This way, whenever we stop or reset the timer,  we also reset the `interval` variable, so it becomes ready to start again when needed.

---

**So here I fixed the timer from going faster when we press "Start" multiple times.  and also fixed the timer so it can resume again from where i was stopped.**





